### PR TITLE
Expire cached blocks using a sweeper_helper on all sweepers

### DIFF
--- a/app/helpers/sweeper_helper.rb
+++ b/app/helpers/sweeper_helper.rb
@@ -20,7 +20,7 @@ module SweeperHelper
 
     # friends blocks
     blocks = profile.blocks.select{|b| b.kind_of?(FriendsBlock)}
-    BlockSweeper.expire_blocks(blocks)
+    expire_blocks(profile)
   end
 
   def expire_communities(profile)
@@ -32,16 +32,37 @@ module SweeperHelper
 
     # communities block
     blocks = profile.blocks.select{|b| b.kind_of?(CommunitiesBlock)}
-    BlockSweeper.expire_blocks(blocks)
+    expire_blocks(profile)
   end
 
   def expire_enterprises(profile)
     # enterprises and favorite enterprises blocks
     blocks = profile.blocks.select {|b| [EnterprisesBlock, FavoriteEnterprisesBlock].any?{|klass| b.kind_of?(klass)} }
-    BlockSweeper.expire_blocks(blocks)
+    expire_blocks(profile)
   end
 
   def expire_profile_index(profile)
     expire_timeout_fragment(profile.relationships_cache_key)
+  end
+
+  def expire_blocks(profile)
+    profile.blocks.each do |block|
+      return if !block.environment
+      regex = '-[a-z]*$'
+      clean_ck = block.cache_key.gsub(/#{regex}/,'')
+      block.environment.locales.keys.each do |locale|
+        expire_timeout_fragment("#{clean_ck}-#{locale}")
+      end
+    end
+  end
+
+  def expire_profile_blocks(blocks)
+    blocks.each do |block|
+      return if !block.environment
+      regex = '-[a-z]*$'
+      clean_ck = block.cache_key.gsub(/#{regex}/,'')
+      block.environment.locales.keys.each do |locale|
+        expire_timeout_fragment("#{clean_ck}-#{locale}")
+      end
   end
 end

--- a/app/sweepers/article_sweeper.rb
+++ b/app/sweepers/article_sweeper.rb
@@ -24,7 +24,7 @@ protected
     blocks = article.profile.blocks
     blocks += article.profile.environment.blocks if article.profile.environment
     blocks = blocks.select{|b|[RecentDocumentsBlock, BlogArchivesBlock].any?{|c| b.kind_of?(c)}}
-    BlockSweeper.expire_blocks(blocks)
+    expire_blocks(profile)
     env = article.profile.environment
     if env && (env.portal_community == article.profile)
       article.environment.locales.keys.each do |locale|

--- a/app/sweepers/block_sweeper.rb
+++ b/app/sweepers/block_sweeper.rb
@@ -5,6 +5,7 @@ class BlockSweeper < ActiveRecord::Observer
   class << self
     include SweeperHelper
 
+    # depreciated, implamented on SweeperHelper
     # Expire block's all languages cache
     def expire_block(block)
       return if !block.environment

--- a/app/sweepers/friendship_sweeper.rb
+++ b/app/sweepers/friendship_sweeper.rb
@@ -35,7 +35,7 @@ protected
     end
 
     blocks = profile.blocks.select{|b| b.kind_of?(FriendsBlock)}
-    BlockSweeper.expire_blocks(blocks)
+    expire_profile_blocks(blocks)
   end
 
 end

--- a/app/sweepers/profile_sweeper.rb
+++ b/app/sweepers/profile_sweeper.rb
@@ -22,16 +22,14 @@ protected
 
     expire_profile_index(profile) if profile.person?
 
-    profile.blocks.each do |block|
-      expire_timeout_fragment(block.cache_key)
-    end
+    expire_blocks(profile)
 
     expire_blogs(profile) if profile.organization?
   end
 
   def expire_statistics_block_cache(profile)
     blocks = profile.environment.blocks.select { |b| b.kind_of?(EnvironmentStatisticsBlock) }
-    BlockSweeper.expire_blocks(blocks)
+   expire_profile_blocks(blocks)
   end
 
   def expire_blogs(profile)

--- a/app/sweepers/role_assignment_sweeper.rb
+++ b/app/sweepers/role_assignment_sweeper.rb
@@ -23,10 +23,7 @@ protected
       expire_timeout_fragment(ck)
     }
 
-    profile.blocks_to_expire_cache.each { |block|
-      blocks = profile.blocks.select{|b| b.kind_of?(block)}
-      BlockSweeper.expire_blocks(blocks)
-    }
+    expire_blocks(profile)
   end
 
 end


### PR DESCRIPTION
Expire cached blocks using a sweeper_helper on all block sweepers, to update {profile} variable immediately after profile updates, instead of wait a block timeout expires after 4 hours since its last used.
