### PR TITLE
Expire cached blocks using a sweeper_helper on all sweepers

### DIFF
--- a/app/helpers/sweeper_helper.rb
+++ b/app/helpers/sweeper_helper.rb
@@ -18,9 +18,10 @@ module SweeperHelper
       expire_timeout_fragment(profile.manage_friends_cache_key(:npage => i.to_s))
     end
 
+    #not tested yet
     # friends blocks
     blocks = profile.blocks.select{|b| b.kind_of?(FriendsBlock)}
-    expire_blocks(profile)
+    expire_profile_blocks(blocks)
   end
 
   def expire_communities(profile)
@@ -32,28 +33,17 @@ module SweeperHelper
 
     # communities block
     blocks = profile.blocks.select{|b| b.kind_of?(CommunitiesBlock)}
-    expire_blocks(profile)
+    expire_profile_blocks(blocks)
   end
 
   def expire_enterprises(profile)
     # enterprises and favorite enterprises blocks
     blocks = profile.blocks.select {|b| [EnterprisesBlock, FavoriteEnterprisesBlock].any?{|klass| b.kind_of?(klass)} }
-    expire_blocks(profile)
+    expire_profile_blocks(blocks)
   end
 
   def expire_profile_index(profile)
     expire_timeout_fragment(profile.relationships_cache_key)
-  end
-
-  def expire_blocks(profile)
-    profile.blocks.each do |block|
-      return if !block.environment
-      regex = '-[a-z]*$'
-      clean_ck = block.cache_key.gsub(/#{regex}/,'')
-      block.environment.locales.keys.each do |locale|
-        expire_timeout_fragment("#{clean_ck}-#{locale}")
-      end
-    end
   end
 
   def expire_profile_blocks(blocks)
@@ -64,5 +54,6 @@ module SweeperHelper
       block.environment.locales.keys.each do |locale|
         expire_timeout_fragment("#{clean_ck}-#{locale}")
       end
+    end
   end
 end

--- a/app/sweepers/article_sweeper.rb
+++ b/app/sweepers/article_sweeper.rb
@@ -24,7 +24,7 @@ protected
     blocks = article.profile.blocks
     blocks += article.profile.environment.blocks if article.profile.environment
     blocks = blocks.select{|b|[RecentDocumentsBlock, BlogArchivesBlock].any?{|c| b.kind_of?(c)}}
-    expire_blocks(profile)
+    expire_profile_blocks(blocks)
     env = article.profile.environment
     if env && (env.portal_community == article.profile)
       article.environment.locales.keys.each do |locale|

--- a/app/sweepers/profile_sweeper.rb
+++ b/app/sweepers/profile_sweeper.rb
@@ -22,14 +22,14 @@ protected
 
     expire_profile_index(profile) if profile.person?
 
-    expire_blocks(profile)
+    expire_profile_blocks(profile.blocks)
 
     expire_blogs(profile) if profile.organization?
   end
 
   def expire_statistics_block_cache(profile)
     blocks = profile.environment.blocks.select { |b| b.kind_of?(EnvironmentStatisticsBlock) }
-   expire_profile_blocks(blocks)
+    expire_profile_blocks(blocks)
   end
 
   def expire_blogs(profile)

--- a/app/sweepers/role_assignment_sweeper.rb
+++ b/app/sweepers/role_assignment_sweeper.rb
@@ -23,7 +23,7 @@ protected
       expire_timeout_fragment(ck)
     }
 
-    expire_blocks(profile)
+    expire_profile_blocks(profile.blocks)
   end
 
 end


### PR DESCRIPTION
Refactoring sweeper_helper and all subclass to use same method (expire_profile_block) every time a block should be "uncache" (call expire cached blocks using a sweeper_helper on all block sweepers), this updates {profile} variable immediately after profile update is requested, instead of wait a block timeout expires after 4 hours since its last used.
