### PR TITLE
Fixing mail notification, use translation for 'shopping_cart|Change'

### DIFF
--- a/plugins/shopping_cart/views/shopping_cart_plugin/mailer/customer_notification.html.erb
+++ b/plugins/shopping_cart/views/shopping_cart_plugin/mailer/customer_notification.html.erb
@@ -19,7 +19,7 @@
       <li><b><%= _('Phone number') %>: </b><%= @customer[:contact_phone] %></li>
       <li><b><%= _('Payment') %>: </b><%= @customer[:payment] == 'money' ? _('Money') : _('Check') %></li>
       <% if @customer[:payment] == 'money' %>
-        <li><b><%= _('Change') %>: </b><%= @customer[:change] %></li>
+        <li><b><%= s_('shopping_cart|Change') %>: </b><%= @customer[:change] %></li>
       <% end %>
       <% if !@customer[:address].blank? || !@customer[:city].blank? || !@customer[:zip_code].blank? || !@customer[:district].blank? || !@customer[:address_reference].blank? %>
         <li><b><%= _('Address') %>:</b>

--- a/plugins/shopping_cart/views/shopping_cart_plugin/mailer/supplier_notification.html.erb
+++ b/plugins/shopping_cart/views/shopping_cart_plugin/mailer/supplier_notification.html.erb
@@ -17,7 +17,7 @@
       <li><b><%= _('Phone number') %>: </b><%= @customer[:contact_phone] %></li>
       <li><b><%= _('Payment') %>: </b><%= @customer[:payment] == 'money' ? _('Money') : _('Check') %></li>
       <% if @customer[:payment] == 'money' %>
-        <li><b><%= _('Change') %>: </b><%= @customer[:change] %></li>
+        <li><b><%= s_('shopping_cart|Change') %>: </b><%= @customer[:change] %></li>
       <% end %>
       <% if !@customer[:address].blank? || !@customer[:city].blank? || !@customer[:zip_code].blank? || !@customer[:district].blank? || !@customer[:address_reference].blank? %>
         <li><b><%= _('Address') %>:</b>


### PR DESCRIPTION
Fixing mail notification, use translation for 'shopping_cart|Change' using s_('bla') instead of _('bla')
