### PR TITLE
Changing contact page message and tip for mailling enterprise admins

### DIFF
--- a/app/views/contact/new.rhtml
+++ b/app/views/contact/new.rhtml
@@ -3,7 +3,7 @@
 <% else %>
   <h1><%= _("Send an e-mail to page administration of this enterprise") %></h1>
 
-  <div class='tooltip'><%= _("The e-mail will be sent to the person who administers the page of '%s'") % profile.name %></div>
+  <div class='tooltip'><%= _("The e-mail will be sent to the people who administers the page of '%s'") % profile.name %></div>
 <% end %>
 
 <%= error_messages_for 'contact' %>

--- a/po/pt/noosfero.po
+++ b/po/pt/noosfero.po
@@ -5474,8 +5474,8 @@ msgid "Send an e-mail to page administration of this enterprise"
 msgstr "Enviar um e-mail para administração da página deste empreendimento"
 
 #: app/views/contact/new.rhtml:6
-msgid "The e-mail will be sent to the person who administers the page of '%s'"
-msgstr "O e-mail será enviado para quem administra a página de '%s'"
+msgid "The e-mail will be sent to the people who administers the page of '%s'"
+msgstr "O e-mail será enviado para as pessoas que administram a página de '%s'"
 
 #: app/views/contact/new.rhtml:23
 msgid "I want to receive a copy of the message in my e-mail."


### PR DESCRIPTION
Previous msg wasnt clear that mesage was to page administration and not enterprise's adiminstration.
