### PR TITLE
Shopping_cart mailer, send notification to admins email in case enterprise contact_email is nil

### DIFF
--- a/plugins/shopping_cart/lib/shopping_cart_plugin/mailer.rb
+++ b/plugins/shopping_cart/lib/shopping_cart_plugin/mailer.rb
@@ -5,14 +5,14 @@ class ShoppingCartPlugin::Mailer < Noosfero::Plugin::MailerBase
   def get_contact_email(supplier)
     contact_email = []
     if supplier.enterprise?
-    if supplier.contact_email.blank?
-      supplier.admins.each do |admin|
-        contact_email << admin.email
+      if supplier.contact_email.blank?
+        supplier.admins.each do |admin|
+          contact_email << admin.email
+        end
+        contact_email
+      else
+        contact_email << supplier.contact_email
       end
-      contact_email
-    else
-      contact_email << supplier.contact_email
-    end
     else
       contact_email
     end


### PR DESCRIPTION
Shopping Cart Plugin, should send notification to admins email in case enterprise contact_email is nil
