### PR TITLE
fix add_zoom_to_images to pass the image class to the wrapper div

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1223,9 +1223,13 @@ module ApplicationHelper
         $('#article .article-body img').each( function(index) {
           var original = original_image_dimensions($(this).attr('src'));
           if ($(this).width() < original['width'] || $(this).height() < original['height']) {
-            $(this).wrap('<div class=\"zoomable-image\" />');
+            var extraClass = ($(this).attr('class'))
+              ? ' '+$(this).attr('class')
+              : '';
+            $(this).wrap('<div class=\"zoomable-image'+extraClass+'\" />');
             $(this).parent('.zoomable-image').attr('style', $(this).attr('style'));
             $(this).attr('style', '');
+            $(this).attr('class', '');
             $(this).after(\'<a href=\"' + $(this).attr('src') + '\" class=\"zoomify-image\"><span class=\"zoomify-text\">%s</span></a>');
           }
         });


### PR DESCRIPTION
Bráulio,

   This is a fix for the problem with the thumbs because of the zoomable-image javascript. The way I fixed is rather simple, but I wasn't able to test it because now that I put the noosfero/stable, I cannot test anymore. And I cannot run it anyway because I erased the database.yml, I kow it was stupid, but since it wasn't being tracked I thought it should not be there. Now I can't even run tests.

```
Ah: a good thing: this change I did don't change any tests, so it can be merged to noosfero with the rest of the commits of the automatic_abstract.

    daniel
```
