### PR TITLE
Fixes sniffer search and category page on pjax and solr

### DIFF
--- a/app/helpers/profile_editor_helper.rb
+++ b/app/helpers/profile_editor_helper.rb
@@ -141,8 +141,9 @@ module ProfileEditorHelper
     )
   end
 
-  def control_panel_button(title, icon, url)
-    link_to title, url, :class => 'control-panel-%s' % icon
+  def control_panel_button(title, icon, url, html_options = {})
+    html_options ||= {}
+    link_to title, url, html_options.merge(:class => 'control-panel-%s' % icon)
   end
 
   def unchangeable_privacy_field(profile)

--- a/app/views/profile_editor/index.html.erb
+++ b/app/views/profile_editor/index.html.erb
@@ -71,7 +71,7 @@
   <%= control_panel_button(_('Edit welcome page'), 'welcome-page', :action => 'welcome_page') if has_welcome_page %>
 
   <% @plugins.dispatch(:control_panel_buttons).each do |button| %>
-    <%= control_panel_button(button[:title], button[:icon], button[:url]) %>
+    <%= control_panel_button(button[:title], button[:icon], button[:url], button[:html_options]) %>
   <% end %>
 
 <% end %>

--- a/lib/noosfero/plugin.rb
+++ b/lib/noosfero/plugin.rb
@@ -208,10 +208,11 @@ class Noosfero::Plugin
   end
 
   # -> Adds buttons to the control panel
-  # returns = { :title => title, :icon => icon, :url => url }
-  #   title = name that will be displayed.
-  #   icon  = css class name (for customized icons include them in a css file).
-  #   url   = url or route to which the button will redirect.
+  # returns        = { :title => title, :icon => icon, :url => url }
+  #   title        = name that will be displayed.
+  #   icon         = css class name (for customized icons include them in a css file).
+  #   url          = url or route to which the button will redirect.
+  #   html_options = aditional html options.
   def control_panel_buttons
     nil
   end

--- a/plugins/pjax/public/javascripts/pjax.js
+++ b/plugins/pjax/public/javascripts/pjax.js
@@ -15,7 +15,7 @@ pjax = {
     var container = '.pjax-container';
     target.addClass('pjax-container');
 
-    jQuery(document).pjax('a', container);
+    jQuery(document).pjax('a:not([data-skip-pjax])', container);
 
     jQuery(document).on('pjax:beforeSend', function(event, xhr, settings) {
       var themes = jQuery.map(pjax.themes, function(theme) { return theme.id }).join(',');

--- a/plugins/sniffer/lib/sniffer_plugin.rb
+++ b/plugins/sniffer/lib/sniffer_plugin.rb
@@ -14,7 +14,7 @@ class SnifferPlugin < Noosfero::Plugin
 
   def control_panel_buttons
     buttons = [{ :title => _("Consumer Interests"), :icon => 'consumer-interests', :url => {:controller => 'sniffer_plugin_myprofile', :action => 'edit'} }]
-    buttons.push( { :title => _("Opportunities Sniffer"), :icon => 'sniff-opportunities', :url => {:controller => 'sniffer_plugin_myprofile', :action => 'search'} } ) if context.profile.enterprise?
+    buttons.push( { :title => _("Opportunities Sniffer"), :icon => 'sniff-opportunities', :url => {:controller => 'sniffer_plugin_myprofile', :action => 'search'}, :html_options => { data: {'skip-pjax' => true} } } ) if context.profile.enterprise?
     buttons
   end
 

--- a/plugins/sniffer/views/sniffer_plugin_myprofile/search.html.erb
+++ b/plugins/sniffer/views/sniffer_plugin_myprofile/search.html.erb
@@ -24,10 +24,10 @@
   </div>
 </div>
 
-<%= content_tag 'script', '', :src => "http://maps.googleapis.com/maps/api/js?sensor=false", :type => 'text/javascript' %>
+<%= javascript_include_tag "//maps.googleapis.com/maps/api/js?sensor=false" %>
 <%= javascript_include_tag 'google_maps' %>
-<%= content_tag 'script', '', :src => "/plugins/sniffer/javascripts/infobox.js", :type => 'text/javascript' %>
-<%= content_tag 'script', '', :src => "/plugins/sniffer/javascripts/custom_marker.js", :type => 'text/javascript' %>
+<%= javascript_include_tag "/plugins/sniffer/javascripts/infobox.js" %>
+<%= javascript_include_tag "/plugins/sniffer/javascripts/custom_marker.js" %>
 <%= javascript_include_tag "/plugins/sniffer/javascripts/underscore-min.js" %>
 <%= javascript_include_tag "/plugins/sniffer/javascripts/sniffer.js" %>
 

--- a/plugins/sniffer/views/sniffer_plugin_myprofile/search.html.erb
+++ b/plugins/sniffer/views/sniffer_plugin_myprofile/search.html.erb
@@ -24,6 +24,13 @@
   </div>
 </div>
 
+<%= content_tag 'script', '', :src => "http://maps.googleapis.com/maps/api/js?sensor=false", :type => 'text/javascript' %>
+<%= javascript_include_tag 'google_maps' %>
+<%= content_tag 'script', '', :src => "/plugins/sniffer/javascripts/infobox.js", :type => 'text/javascript' %>
+<%= content_tag 'script', '', :src => "/plugins/sniffer/javascripts/custom_marker.js", :type => 'text/javascript' %>
+<%= javascript_include_tag "/plugins/sniffer/javascripts/underscore-min.js" %>
+<%= javascript_include_tag "/plugins/sniffer/javascripts/sniffer.js" %>
+
 <script id="marker-template" type="text/html">
   <div class="marker-wrap">
     <img src="<@= icon @>" alt="<@= title @>"/>
@@ -31,42 +38,19 @@
 </script>
 
 <script type='text/javascript'>
-  function loadScript(url, callback) {
-    var script = document.createElement('script');
-    if (callback) {
-      // FF fires onload and IE fires onreadystatechange
-      script.onload = callback;
-      script.onreadystatechange = callback;
-    }
-    script.type = 'text/javascript';
-    script.src = url;
-    document.body.appendChild(script);
-  };
-
-  function mapApiReady() {
-    loadScript('/plugins/sniffer/javascripts/infobox.js');
-    loadScript('/plugins/sniffer/javascripts/custom_marker.js', loadSnifferMap);
-  };
-
   var currentProfile = <%= profile_hash(profile).to_json %>;
-
-  function loadSnifferMap() {
-    sniffer.search.map.load({
-      "zoom": <%= GoogleMaps.initial_zoom.to_json %>,
-      "balloonUrl": <%= url_for(:controller => :sniffer_plugin_myprofile, :action => :map_balloon, :id => "_id_", :escape => false).to_json %>,
-      "myBalloonUrl": <%= url_for(:controller => :sniffer_plugin_myprofile, :action => :my_map_balloon, :escape => false).to_json %>,
-      "profiles": <%=
-        @profiles_data.map do |id, profile_data|
-          data = profile_hash(profile_data[:profile])
-          data[:consumersProducts] = profile_data[:consumers_products]
-          data[:suppliersProducts] = profile_data[:suppliers_products]
-          data[:icon] = profile_data[:profile][:icon]
-          data
-        end.to_json
-      %>
-    });
-  };
+  sniffer.search.map.load({
+    "zoom": <%= GoogleMaps.initial_zoom.to_json %>,
+    "balloonUrl": <%= url_for(:controller => :sniffer_plugin_myprofile, :action => :map_balloon, :id => "_id_", :escape => false).to_json %>,
+    "myBalloonUrl": <%= url_for(:controller => :sniffer_plugin_myprofile, :action => :my_map_balloon, :escape => false).to_json %>,
+    "profiles": <%=
+      @profiles_data.map do |id, profile_data|
+        data = profile_hash(profile_data[:profile])
+        data[:consumersProducts] = profile_data[:consumers_products]
+        data[:suppliersProducts] = profile_data[:suppliers_products]
+        data[:icon] = profile_data[:profile][:icon]
+        data
+      end.to_json
+    %>
+  });
 </script>
-
-<%= javascript_include_tag "//maps.googleapis.com/maps/api/js?sensor=false&callback=mapApiReady" %>
-<%= javascript_include_tag 'google_maps' %>

--- a/plugins/solr/lib/solr_plugin/base.rb
+++ b/plugins/solr/lib/solr_plugin/base.rb
@@ -110,8 +110,7 @@ class SolrPlugin::Base < Noosfero::Plugin
     end
 
     solr_options[:filter_queries] ||= []
-    solr_options[:filter_queries] += solr_filters_queries asset
-    solr_options[:filter_queries] << "environment_id:#{environment.id}"
+    solr_options[:filter_queries] += solr_filters_queries asset, environment
     solr_options[:filter_queries] << klass.facet_category_query.call(category) if category
     solr_options[:filter_queries] += scopes_to_solr_options scope, klass, options
 

--- a/plugins/solr/lib/solr_plugin/search_helper.rb
+++ b/plugins/solr/lib/solr_plugin/search_helper.rb
@@ -40,14 +40,14 @@ module SolrPlugin::SearchHelper
     ],
   }
 
-  def solr_filters_queries asset
+  def solr_filters_queries asset, environment
     case asset
     when :products
       ['solr_plugin_public:true', 'enabled:true']
-    when :catalog
+    when :catalog, :events, :categories, :product_categories
       []
-    when :events
-      []
+    when :profiles, :people, :organizations, :communities, :enterprises
+      ['solr_plugin_public:true', 'environment_id:%s' % environment.id]
     else
       ['solr_plugin_public:true']
     end

--- a/test/functional/profile_editor_controller_test.rb
+++ b/test/functional/profile_editor_controller_test.rb
@@ -941,7 +941,7 @@ class ProfileEditorControllerTest < ActionController::TestCase
 
     class TestControlPanelButtons1 < Noosfero::Plugin
       def control_panel_buttons
-        {:title => "Plugin1 button", :icon => 'plugin1_icon', :url => 'plugin1_url'}
+        {:title => "Plugin1 button", :icon => 'plugin1_icon', :url => 'plugin1_url', :html_options => { :data => {extra: true} }}
       end
     end
     class TestControlPanelButtons2 < Noosfero::Plugin
@@ -955,8 +955,8 @@ class ProfileEditorControllerTest < ActionController::TestCase
 
     get :index, :profile => profile.identifier
 
-    assert_tag :tag => 'a', :content => 'Plugin1 button', :attributes => {:class => /plugin1_icon/, :href => /plugin1_url/}
-    assert_tag :tag => 'a', :content => 'Plugin2 button', :attributes => {:class => /plugin2_icon/, :href => /plugin2_url/}
+    assert_tag :tag => 'a', :content => 'Plugin1 button', :attributes => {:class => /plugin1_icon/, :href => /plugin1_url/, :'data-extra' => true}
+    assert_tag :tag => 'a', :content => 'Plugin2 button', :attributes => {:class => /plugin2_icon/, :href => /plugin2_url/, :'data-extra' => nil}
   end
 
   should 'add extra content provided by plugins on edit' do


### PR DESCRIPTION
While the sniffer search page was working locally, for what I now believe to be magic, the same couldn't be said about working on cirandas' test server. That way, I had to resort to another approach and instead not load the search page with pjax.

Meanwhile, the category search inside sniffer plugin was also crashing on solr. This was fixed by avoiding to use an unindexed attribute on solr filter queries.
